### PR TITLE
Moved LibGDX ignores to own .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,34 +46,5 @@ ipch/
 hs_err_pid*
 Thumbs.db
 
-libgdx-*.zip
-libgdx-*.zip.MD5
-
 *.iml
 .idea/
-
-#core & extension libs/ folders that have no 3rd party dependencies in them
-/gdx/libs
-/backends/gdx-backend-jglfw/libs/
-/backends/gdx-backend-robovm/libs/
-/extensions/gdx-audio/libs/
-/extensions/gdx-box2d/gdx-box2d/libs/
-/extensions/gdx-bullet/libs/
-/extensions/gdx-controllers/gdx-controllers-desktop/libs/
-/extensions/gdx-freetype/libs/
-/extensions/gdx-image/libs/
-/extensions/gdx-setup/gdx-setup.jar
-/extensions/gdx-setup/test/
-
-#the LWJGL3 libs are pulled via fetch.xml
-/backends/gdx-backend-lwjgl3/libs/lwjgl*.jar
-
-#ensure gdx-setup.jar works properly
-!/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gwt/war
-
-#directories created by fetch.xml
-/tests/gdx-tests-android/libs
-/tmp/
-
-#gradle wrapper
-/local.properties

--- a/Server Frontend/.gitignore
+++ b/Server Frontend/.gitignore
@@ -1,0 +1,28 @@
+libgdx-*.zip
+libgdx-*.zip.MD5
+
+#core & extension libs/ folders that have no 3rd party dependencies in them
+/gdx/libs
+/backends/gdx-backend-jglfw/libs/
+/backends/gdx-backend-robovm/libs/
+/extensions/gdx-audio/libs/
+/extensions/gdx-box2d/gdx-box2d/libs/
+/extensions/gdx-bullet/libs/
+/extensions/gdx-controllers/gdx-controllers-desktop/libs/
+/extensions/gdx-freetype/libs/
+/extensions/gdx-image/libs/
+/extensions/gdx-setup/gdx-setup.jar
+/extensions/gdx-setup/test/
+
+#the LWJGL3 libs are pulled via fetch.xml
+/backends/gdx-backend-lwjgl3/libs/lwjgl*.jar
+
+#ensure gdx-setup.jar works properly
+!/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gwt/war
+
+#directories created by fetch.xml
+/tests/gdx-tests-android/libs
+/tmp/
+
+#gradle wrapper
+/local.properties


### PR DESCRIPTION
- sub-project ignores so we can be specific per project and not dirty
the overall .gitignore when working on a specific project that needs
files to be ignored